### PR TITLE
Simple download

### DIFF
--- a/download.go
+++ b/download.go
@@ -4,17 +4,19 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 )
 
 func (s Server) handleDownload(w http.ResponseWriter, r *http.Request) {
-	filePath := filepath.Base(r.URL.Path)
-	stream, err := s.Storage.Download(r.Context(), filePath)
+	fullpath := strings.TrimPrefix(r.URL.RequestURI(), s.GetPrefixPath)
+	objectKey := filepath.Base(fullpath)
+	stream, err := s.Storage.Download(r.Context(), objectKey)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if stream == nil {
-		http.Error(w, "Not found", http.StatusNotFound)
+		http.Error(w, fullpath, http.StatusNotFound)
 		return
 	}
 	io.Copy(w, stream)

--- a/download.go
+++ b/download.go
@@ -1,0 +1,6 @@
+package attache
+
+import "net/http"
+
+func (s Server) handleDownload(w http.ResponseWriter, r *http.Request) {
+}

--- a/download.go
+++ b/download.go
@@ -1,6 +1,21 @@
 package attache
 
-import "net/http"
+import (
+	"io"
+	"net/http"
+	"path/filepath"
+)
 
 func (s Server) handleDownload(w http.ResponseWriter, r *http.Request) {
+	filePath := filepath.Base(r.URL.Path)
+	stream, err := s.Storage.Download(r.Context(), filePath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if stream == nil {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+	io.Copy(w, stream)
 }

--- a/download_test.go
+++ b/download_test.go
@@ -29,6 +29,12 @@ func TestHandleDownload(t *testing.T) {
 			expectedStatus:   http.StatusOK,
 			expectedFile:     "testdata/transparent.gif",
 		},
+		{
+			givenURI:         "/wrong.txt?%s",
+			givenFile:        "testdata/transparent.gif",
+			givenContentType: "image/gif",
+			expectedStatus:   http.StatusNotFound,
+		},
 	}
 
 	for i, tc := range testCases {
@@ -48,6 +54,9 @@ func TestHandleDownload(t *testing.T) {
 
 			result := w.Result()
 			assert.Equal(t, tc.expectedStatus, result.StatusCode)
+			if result.StatusCode != http.StatusOK {
+				return
+			}
 
 			expectedBytes, err := ioutil.ReadFile(tc.expectedFile)
 			if err != nil {

--- a/download_test.go
+++ b/download_test.go
@@ -1,0 +1,64 @@
+package attache
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/net/context"
+)
+
+func TestHandleDownload(t *testing.T) {
+	testCases := []struct {
+		givenURI         string
+		givenFile        string
+		givenContentType string
+		expectedStatus   int
+		expectedFile     string
+	}{
+		{
+			givenURI:         "/%s",
+			givenFile:        "testdata/transparent.gif",
+			givenContentType: "image/gif",
+			expectedStatus:   http.StatusOK,
+			expectedFile:     "testdata/transparent.gif",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			file, err := os.Open(tc.givenFile)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			defer file.Close()
+			store := newDummyStore()
+			store.Upload(context.Background(), file, tc.givenContentType)
+
+			r := httptest.NewRequest("GET", fmt.Sprintf(tc.givenURI, store.LastUniqueKey), nil)
+			w := httptest.NewRecorder()
+			s := Server{Storage: store}
+			s.ServeHTTP(w, r)
+
+			result := w.Result()
+			assert.Equal(t, tc.expectedStatus, result.StatusCode)
+
+			expectedBytes, err := ioutil.ReadFile(tc.expectedFile)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			actualBytes, err := ioutil.ReadAll(result.Body)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			defer result.Body.Close()
+			assert.Equal(t, expectedBytes, actualBytes)
+		})
+	}
+}

--- a/gcloudstore/README.md
+++ b/gcloudstore/README.md
@@ -8,8 +8,14 @@ func main() {
 
 	http.Handle(nodego.HTTPTrigger, attache.Server{
 		Storage: gcloudstore.NewStore("your-bucket-name"),
+		GetPrefixPath: "/execute?",
 	})
 
 	nodego.TakeOver()
 }
 ```
+
+NOTE:
+- Google Cloud Function http endpoint matches request path strictly, e.g. `/attache` works but `/attache/thing.jpg` is 404.
+- To workaround that, we need to specify the url as `/attache?thing.jpg` instead
+- But internally our http server sees the prefix as `/execute` ¯\_(ツ)_/¯, so we have to configure `GetPrefixPath: "/execute?"`

--- a/gcloudstore/gcloud.go
+++ b/gcloudstore/gcloud.go
@@ -1,7 +1,6 @@
 package gcloudstore
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"math"
@@ -30,7 +29,7 @@ func NewStore(bucketName string) Store {
 }
 
 // Upload fulfills attache.Store interface
-func (s Store) Upload(ctx context.Context, src *bytes.Reader, fileType string) (string, error) {
+func (s Store) Upload(ctx context.Context, src io.ReadSeeker, fileType string) (string, error) {
 	fileName := filename(fileType)
 
 	client, err := storage.NewClient(ctx)

--- a/gcloudstore/gcloud.go
+++ b/gcloudstore/gcloud.go
@@ -48,6 +48,23 @@ func (s Store) Upload(ctx context.Context, src io.ReadSeeker, fileType string) (
 	return fileName, nil
 }
 
+// Download fulfills attache.Store interface
+func (s Store) Download(ctx context.Context, filePath string) (io.ReadCloser, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "storage newclient")
+	}
+	body, err := client.Bucket(s.bucketName).Object(filePath).NewReader(ctx)
+	if err == storage.ErrBucketNotExist || err == storage.ErrObjectNotExist {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "storage newreader")
+	}
+
+	return body, nil
+}
+
 func filename(fileType string) string {
 	// Sorts in Reverse Chrono Order
 	key := strconv.FormatInt((math.MaxInt64 - time.Now().UnixNano()), 10)

--- a/s3store/s3.go
+++ b/s3store/s3.go
@@ -1,8 +1,8 @@
 package s3store
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"strings"
@@ -23,7 +23,7 @@ type Store struct {
 }
 
 // Upload fulfills attache.Store interface
-func (s Store) Upload(ctx context.Context, file *bytes.Reader, fileType string) (string, error) {
+func (s Store) Upload(ctx context.Context, file io.ReadSeeker, fileType string) (string, error) {
 	fileName := filename(fileType)
 	filePath := fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", os.Getenv("AWS_REGION"), s.Bucket, fileName)
 

--- a/server.go
+++ b/server.go
@@ -20,7 +20,8 @@ type uploadMeta struct {
 
 // Server handles upload and download
 type Server struct {
-	Storage Store
+	Storage       Store
+	GetPrefixPath string // e.g. `/execute?` we strip away this prefix before we extract `filePath`
 }
 
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/server.go
+++ b/server.go
@@ -33,6 +33,9 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		json.NewEncoder(w).Encode(result)
 
+	case "GET":
+		s.handleDownload(w, r)
+
 	case "OPTIONS":
 		w.Header().Set("Access-Control-Allow-Methods", "POST, PUT, PATCH, OPTIONS")
 

--- a/store.go
+++ b/store.go
@@ -8,4 +8,5 @@ import (
 
 type Store interface {
 	Upload(ctx context.Context, file io.ReadSeeker, fileType string) (filePath string, err error)
+	Download(ctx context.Context, filePath string) (io.ReadCloser, error) // should return `nil, nil` for when `filePath` is not found
 }

--- a/store.go
+++ b/store.go
@@ -1,11 +1,11 @@
 package attache
 
 import (
-	"bytes"
+	"io"
 
 	"golang.org/x/net/context"
 )
 
 type Store interface {
-	Upload(ctx context.Context, file *bytes.Reader, fileType string) (filePath string, err error)
+	Upload(ctx context.Context, file io.ReadSeeker, fileType string) (filePath string, err error)
 }

--- a/store_test.go
+++ b/store_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 type dummyStore struct {
-	hash map[string][]byte // default is `nil`
+	hash          map[string][]byte // default is `nil`
+	LastUniqueKey string
 }
 
 func newDummyStore() *dummyStore {
@@ -30,6 +31,7 @@ func (s *dummyStore) Upload(ctx context.Context, file io.ReadSeeker, fileType st
 	}
 
 	uniqueKey := uuid.NewV4().String()
+	s.LastUniqueKey = uniqueKey
 	s.hash[uniqueKey] = data
 	return uniqueKey, nil
 }

--- a/store_test.go
+++ b/store_test.go
@@ -4,7 +4,7 @@
 package attache
 
 import (
-	"bytes"
+	"io"
 	"io/ioutil"
 
 	"golang.org/x/net/context"
@@ -23,7 +23,7 @@ func newDummyStore() *dummyStore {
 }
 
 // Upload fulfills attache.Store interface
-func (s *dummyStore) Upload(ctx context.Context, file *bytes.Reader, fileType string) (string, error) {
+func (s *dummyStore) Upload(ctx context.Context, file io.ReadSeeker, fileType string) (string, error) {
 	data, err := ioutil.ReadAll(file)
 	if err != nil {
 		return "", err

--- a/store_test.go
+++ b/store_test.go
@@ -4,6 +4,7 @@
 package attache
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 
@@ -34,6 +35,16 @@ func (s *dummyStore) Upload(ctx context.Context, file io.ReadSeeker, fileType st
 	s.LastUniqueKey = uniqueKey
 	s.hash[uniqueKey] = data
 	return uniqueKey, nil
+}
+
+// Download fulfills attache.Store interface
+func (s *dummyStore) Download(ctx context.Context, filePath string) (io.ReadCloser, error) {
+	data, ok := s.hash[filePath]
+	if !ok {
+		return nil, nil
+	}
+
+	return ioutil.NopCloser(bytes.NewReader(data)), nil
 }
 
 // compile-time check that we implement attache.Store interface


### PR DESCRIPTION
- pulls object from backend and send the bytes directly out via `http.ResponseWriter` (no processing)
- 404 if object is not found in backend

---

unfortunately, some lambda platforms (e.g. google cloud) gives very specific url 

i.e.

```
https://xyz.cloudfunctions.net/attache
```

will hit your lambda function, but

```
https://xyz.cloudfunctions.net/attache/abc
```

will NOT hit your lambda function; returns 404

so in order for us to retrieve images like 

```
https://xyz.cloudfunctions.net/attache/resize/100x/987654321.gif
```

we'd need to specify instead as,

```
https://xyz.cloudfunctions.net/attache?resize/100x/987654321.gif
```

and do some `strings.TrimPrefix(r.URL.RequestURI(), "/attache?")` to obtain the `"resize/100x/987654321.gif"`
